### PR TITLE
feat(api): improvements for lineage creation

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -170,8 +170,6 @@ components:
           type: integer
         maxNonceValue:
           type: integer
-        version:
-          type: integer
 
     TicketLeaseRequest:
       type: object

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -21,6 +21,23 @@ paths:
               schema:
                 $ref: "#/components/schemas/LineageCreationResponse"
 
+  /lineages/{lineageId}:
+    get:
+      operationId: getLineage
+      parameters:
+        - name: lineageId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Lineage retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LineageGetResponse"
+
   /lineages/{lineageId}/tickets:
     post:
       operationId: leaseTicket
@@ -119,12 +136,42 @@ components:
           maximum: 9223372036854775807
 
     LineageCreationResponse:
-      type: object
+      required:
+        - id
+        - extId
       properties:
         id:
           type: string
         extId:
           type: string
+
+    LineageGetResponse:
+      required:
+        - id
+        - extId
+        - nextNonce
+        - leasedNonceCount
+        - releasedNonceCount
+        - maxLeasedNonceCount
+        - maxNonceValue
+        - version
+      properties:
+        id:
+          type: string
+        extId:
+          type: string
+        nextNonce:
+          type: integer
+        leasedNonceCount:
+          type: integer
+        releasedNonceCount:
+          type: integer
+        maxLeasedNonceCount:
+          type: integer
+        maxNonceValue:
+          type: integer
+        version:
+          type: integer
 
     TicketLeaseRequest:
       type: object
@@ -136,6 +183,12 @@ components:
 
     TicketLeaseResponse:
       type: object
+      required:
+        - lineageId
+        - extId
+        - nonce
+        - leasedAt
+        - state
       properties:
         lineageId:
           type: string

--- a/pkg/openapi/api.go
+++ b/pkg/openapi/api.go
@@ -57,6 +57,10 @@ func (h *ApiHandler) CreateLineage(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, resp)
 }
 
+func (h *ApiHandler) GetLineage(ctx echo.Context, lineageId string) error {
+	panic("implement me")
+}
+
 func (h *ApiHandler) LeaseTicket(ctx echo.Context, lineageId string) error {
 	req := &api.TicketLeaseRequest{}
 	err := ctx.Bind(req)

--- a/pkg/openapi/api.go
+++ b/pkg/openapi/api.go
@@ -19,6 +19,7 @@ import (
 
 const port = 5010
 
+const ErrorCodeNotFound = "not_found"
 const ErrorCodeBadRequest = "bad_request"
 const ErrorCodeTooManyLeasedTickets = "too_many_leased_tickets"
 
@@ -51,6 +52,13 @@ func (h *ApiHandler) CreateLineage(ctx echo.Context) error {
 
 	resp, err := h.servicer.CreateLineage(req)
 	if err != nil {
+		if err == ticket.ErrInvalidRequest {
+			return ctx.JSON(http.StatusBadRequest, api.Error{
+				Code:    ErrorCodeBadRequest,
+				Message: err.Error(),
+			})
+		}
+
 		return err
 	}
 
@@ -58,7 +66,19 @@ func (h *ApiHandler) CreateLineage(ctx echo.Context) error {
 }
 
 func (h *ApiHandler) GetLineage(ctx echo.Context, lineageId string) error {
-	panic("implement me")
+	resp, err := h.servicer.GetLineage(lineageId)
+	if err != nil {
+		if err == ticket.ErrNoSuchLineage {
+			return ctx.JSON(http.StatusNotFound, api.Error{
+				Code:    ErrorCodeNotFound,
+				Message: err.Error(),
+			})
+		}
+
+		return err
+	}
+
+	return ctx.JSON(http.StatusOK, resp)
 }
 
 func (h *ApiHandler) LeaseTicket(ctx echo.Context, lineageId string) error {

--- a/pkg/psqlticket/psql_ticket_servicer.go
+++ b/pkg/psqlticket/psql_ticket_servicer.go
@@ -111,7 +111,6 @@ func (p *Servicer) GetLineage(extId string) (*api.LineageGetResponse, error) {
 		ReleasedNonceCount:  releasedNonceCount,
 		MaxLeasedNonceCount: maxLeasedNonceCount,
 		MaxNonceValue:       maxNonceValue,
-		Version:             version,
 	}
 
 	log.Info().

--- a/pkg/psqlticket/psql_ticket_servicer.go
+++ b/pkg/psqlticket/psql_ticket_servicer.go
@@ -17,6 +17,9 @@ released_nonce_count, max_leased_nonce_count, max_nonce_value, version)
 values ($1, $2, $3, 0, 0, $4, 9223372036854775807, 0) 
 returning id;`
 
+const QueryStringSelectLineageByExtId = `select id, next_nonce, leased_nonce_count, 
+released_nonce_count, max_leased_nonce_count, max_nonce_value, version from lineages where ext_id = $1`
+
 const QueryStringCreateTicket = `select create_ticket($1, $2, $3);`
 const QueryStringReleaseTicket = `select release_ticket($1, $2, $3);`
 const QueryStringCloseTicket = `select close_ticket($1, $2, $3);`
@@ -47,6 +50,14 @@ func (p *Servicer) CreateLineage(request *api.LineageCreationRequest) (*api.Line
 	rows, err := p.db.QueryContext(context.TODO(), QueryStringInsertLineage,
 		aUuid.String(), request.ExtId, request.StartLeasingFrom, request.MaxLeasedNonceCount)
 	if err != nil {
+		if pqErr, ok := err.(*pq.Error); ok {
+			switch pqErr.Constraint {
+			case "lineages_ext_id_idx":
+				return nil, ticket.ErrInvalidRequest
+			default:
+				return nil, err
+			}
+		}
 		return nil, err
 	}
 
@@ -60,9 +71,54 @@ func (p *Servicer) CreateLineage(request *api.LineageCreationRequest) (*api.Line
 	}
 
 	resp := &api.LineageCreationResponse{
-		Id:    &lineageId,
-		ExtId: &request.ExtId,
+		Id:    lineageId,
+		ExtId: request.ExtId,
 	}
+
+	log.Info().
+		Str("id", lineageId).
+		Str("extId", request.ExtId).
+		Msg("created lineage")
+
+	return resp, nil
+}
+
+func (p *Servicer) GetLineage(extId string) (*api.LineageGetResponse, error) {
+	var id string
+	var nextNonce int
+	var leasedNonceCount int
+	var releasedNonceCount int
+	var maxLeasedNonceCount int
+	var maxNonceValue int
+	var version int
+
+	err := p.db.QueryRowContext(context.TODO(), QueryStringSelectLineageByExtId, extId).
+		Scan(&id, &nextNonce, &leasedNonceCount,
+			&releasedNonceCount, &maxLeasedNonceCount, &maxNonceValue, &version)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ticket.ErrNoSuchLineage
+		}
+
+		return nil, err
+	}
+
+	resp := &api.LineageGetResponse{
+		Id:                  id,
+		ExtId:               extId,
+		NextNonce:           nextNonce,
+		LeasedNonceCount:    leasedNonceCount,
+		ReleasedNonceCount:  releasedNonceCount,
+		MaxLeasedNonceCount: maxLeasedNonceCount,
+		MaxNonceValue:       maxNonceValue,
+		Version:             version,
+	}
+
+	log.Info().
+		Str("lineageId", id).
+		Str("extId", extId).
+		Int("version", version).
+		Msg("retrieved lineage")
 
 	return resp, nil
 }
@@ -101,15 +157,15 @@ func (p *Servicer) LeaseTicket(lineageId string, request *api.TicketLeaseRequest
 	}
 
 	resp := &api.TicketLeaseResponse{
-		LineageId: &lineageId,
-		ExtId:     &request.ExtId,
-		Nonce:     nonce,
+		LineageId: lineageId,
+		ExtId:     request.ExtId,
+		Nonce:     *nonce,
 	}
 
 	log.Info().
-		Str("lineage", *resp.LineageId).
-		Str("ref", *resp.ExtId).
-		Int("nonce", *resp.Nonce).
+		Str("lineageId", resp.LineageId).
+		Str("extId", resp.ExtId).
+		Int("nonce", resp.Nonce).
 		Msg("leased ticket")
 
 	return resp, nil
@@ -129,12 +185,18 @@ func (p *Servicer) GetTicket(lineageId string, ticketExtId string) (*api.TicketL
 	state := api.TicketLeaseResponseState(stateStr)
 
 	resp := &api.TicketLeaseResponse{
-		ExtId:     &ticketExtId,
-		LeasedAt:  &leasedAtStr,
-		LineageId: &lineageId,
-		Nonce:     &nonce,
-		State:     &state,
+		ExtId:     ticketExtId,
+		LeasedAt:  leasedAtStr,
+		LineageId: lineageId,
+		Nonce:     nonce,
+		State:     state,
 	}
+
+	log.Info().
+		Str("lineageId", lineageId).
+		Str("extId", ticketExtId).
+		Str("leased_at", leasedAtStr).
+		Msg("retrieved ticket")
 
 	return resp, nil
 }
@@ -163,8 +225,8 @@ func (p *Servicer) ReleaseTicket(lineageId string, ticketExtId string) error {
 	}
 
 	log.Info().
-		Str("lineage", lineageId).
-		Str("ref", ticketExtId).
+		Str("lineageId", lineageId).
+		Str("extId", ticketExtId).
 		Int("nonce", *nonce).
 		Msg("released ticket")
 
@@ -183,8 +245,8 @@ func (p *Servicer) CloseTicket(lineageId string, ticketExtId string) error {
 	}
 
 	log.Info().
-		Str("lineage", lineageId).
-		Str("ref", ticketExtId).
+		Str("lineageId", lineageId).
+		Str("extId", ticketExtId).
 		Msg("closed ticket")
 
 	return nil

--- a/pkg/ticket/ticket_servicer.go
+++ b/pkg/ticket/ticket_servicer.go
@@ -14,6 +14,7 @@ var (
 
 type Servicer interface {
 	CreateLineage(request *api.LineageCreationRequest) (*api.LineageCreationResponse, error)
+	GetLineage(extId string) (*api.LineageGetResponse, error)
 	LeaseTicket(lineageId string, request *api.TicketLeaseRequest) (*api.TicketLeaseResponse, error)
 	GetTicket(lineageId string, ticketExtId string) (*api.TicketLeaseResponse, error)
 	ReleaseTicket(lineageId string, ticketExtId string) error

--- a/scripts/psql/migrations/1_initialize_schema.up.sql
+++ b/scripts/psql/migrations/1_initialize_schema.up.sql
@@ -26,6 +26,8 @@ create table if not exists lineages
     primary key (id)
 );
 
+create unique index lineages_ext_id_idx on lineages(ext_id);
+
 create table if not exists tickets
 (
     lineage_id   uuid,
@@ -58,10 +60,6 @@ create table if not exists lockz
     owner                 character varying(255)
 );
 create sequence lockz_rvn owned by public.lockz.record_version_number;
-
-insert into lineages(id, ext_id, next_nonce, leased_nonce_count, released_nonce_count, max_leased_nonce_count,
-                     max_nonce_value, version)
-values ('96b68897-9a1f-4d66-b158-a66a2bafcace', 'default', 0, 0, 0, 64, 9223372036854775807, 0);
 
 create or replace function create_ticket(
     _lineage_id uuid,


### PR DESCRIPTION
The purpose of this PR is to add a GetLineage call for clients to be able to benefit of automatic management of lineages based on an externally manged extId for a lineage.

Normally the client can construct the extId based on some information about the identity from the blockchain (e.g. address of key) and "ensure" that the appropriate lineage exists in dinonce.