### PR TITLE
fix(psql): added validation and error handling for non-existent ticke…

### DIFF
--- a/cmd/dinonce/main.go
+++ b/cmd/dinonce/main.go
@@ -68,7 +68,12 @@ func main() {
 			if err != nil {
 				log.Fatal().Err(err).Msg("can not open db connection")
 			}
-			defer db.Close()
+			defer func(db *sql.DB) {
+				err := db.Close()
+				if err != nil {
+					log.Error().Err(err).Msg("can not close db")
+				}
+			}(db)
 
 			driver, err := postgres.WithInstance(db, &postgres.Config{})
 			if err != nil {
@@ -101,7 +106,12 @@ func main() {
 				log.Fatal().Err(err).Msg("can not acquire lock")
 			}
 
-			defer l.Close()
+			defer func(l *pglock.Lock) {
+				err := l.Close()
+				if err != nil {
+					log.Error().Err(err).Msg("can not close pgLock")
+				}
+			}(l)
 			svc = psqlticket.NewServicer(db)
 		}
 

--- a/pkg/openapi/api.go
+++ b/pkg/openapi/api.go
@@ -129,16 +129,16 @@ func (h *ApiHandler) UpdateTicket(ctx echo.Context, lineageId string, ticketExtI
 	switch req.State {
 	case api.TicketUpdateRequestStateReleased:
 		err = h.servicer.ReleaseTicket(lineageId, ticketExtId)
-		if err != nil {
-			return err
-		}
 	case api.TicketUpdateRequestStateClosed:
-		err := h.servicer.CloseTicket(lineageId, ticketExtId)
-		if err != nil {
-			return err
-		}
+		err = h.servicer.CloseTicket(lineageId, ticketExtId)
 	default:
 		ctx.Error(errors.New("state must be one of:(released,closed)"))
+	}
+	if err != nil {
+		if err == ticket.ErrNoSuchTicket {
+			return ctx.NoContent(http.StatusNotFound)
+		}
+		return err
 	}
 
 	return ctx.NoContent(http.StatusNoContent)

--- a/pkg/psqlticket/psql_ticket_servicer_test.go
+++ b/pkg/psqlticket/psql_ticket_servicer_test.go
@@ -106,7 +106,7 @@ func TestServicer_GetLineage(t *testing.T) {
 	}
 }
 
-func TestServicer_GetLineage_NoLineageError(t *testing.T) {
+func TestServicer_GetLineage_NoSuchLineageError(t *testing.T) {
 	id, _ := uuid.NewUUID()
 
 	_, err := victim.GetLineage(id.String())
@@ -119,7 +119,7 @@ func TestServicer_GetLineage_NoLineageError(t *testing.T) {
 	}
 }
 
-func TestServicer_LeaseTicket_SingleTicketOk(t *testing.T) {
+func TestServicer_LeaseTicket(t *testing.T) {
 	lineageId := createLineage(t)
 
 	request := &api.TicketLeaseRequest{
@@ -136,7 +136,7 @@ func TestServicer_LeaseTicket_SingleTicketOk(t *testing.T) {
 	}
 }
 
-func TestServicer_LeaseTicket_SingleTicketIdempotencyWithSameNonce(t *testing.T) {
+func TestServicer_LeaseTicket_WithSameNonce(t *testing.T) {
 	lineageId := createLineage(t)
 
 	request := &api.TicketLeaseRequest{
@@ -163,7 +163,7 @@ func TestServicer_LeaseTicket_SingleTicketIdempotencyWithSameNonce(t *testing.T)
 	}
 }
 
-func TestServicer_LeaseTicket_SingleTicketClose(t *testing.T) {
+func TestServicer_CloseTicket(t *testing.T) {
 	lineageId := createLineage(t)
 
 	request := &api.TicketLeaseRequest{
@@ -185,7 +185,20 @@ func TestServicer_LeaseTicket_SingleTicketClose(t *testing.T) {
 	}
 }
 
-func TestServicer_LeaseTicket_SingleTicketCloseAndAfterCreateValidation(t *testing.T) {
+func TestServicer_CloseTicket_NoSuchTicketError(t *testing.T) {
+	lineageId := createLineage(t)
+
+	err := victim.CloseTicket(lineageId, "nonexistent")
+	if err == nil {
+		t.Error("should not be able to close nonexistent ticket")
+	}
+
+	if err != ticket.ErrNoSuchTicket {
+		t.Errorf("expected ErrNoSuchTicket, got %s", err)
+	}
+}
+
+func TestServicer_LeaseTicket_InvalidRequestErrorOnClosedExtId(t *testing.T) {
 	lineageId := createLineage(t)
 
 	request := &api.TicketLeaseRequest{
@@ -216,7 +229,7 @@ func TestServicer_LeaseTicket_SingleTicketCloseAndAfterCreateValidation(t *testi
 	}
 }
 
-func TestServicer_LeaseTicket_MaxLeasedNonceCountValidation(t *testing.T) {
+func TestServicer_LeaseTicket_TooManyLeasedTicketsError(t *testing.T) {
 	lineageId := createLineage(t)
 
 	for i := 0; i < maxLeasedNonceCount; i++ {
@@ -240,7 +253,7 @@ func TestServicer_LeaseTicket_MaxLeasedNonceCountValidation(t *testing.T) {
 	}
 }
 
-func TestServicer_LeaseTicket_ReleasedNonceCorrectReassignment(t *testing.T) {
+func TestServicer_LeaseTicket_ReleasedNonceReassignment(t *testing.T) {
 	lineageId := createLineage(t)
 
 	request := &api.TicketLeaseRequest{
@@ -268,7 +281,20 @@ func TestServicer_LeaseTicket_ReleasedNonceCorrectReassignment(t *testing.T) {
 	}
 }
 
-func TestServicer_GetTicket_LeasedOk(t *testing.T) {
+func TestServicer_ReleaseTicket_NoSuchTicket(t *testing.T) {
+	lineageId := createLineage(t)
+
+	err := victim.ReleaseTicket(lineageId, "nonexistent")
+	if err == nil {
+		t.Error("should not be able to close nonexistent ticket")
+	}
+
+	if err != ticket.ErrNoSuchTicket {
+		t.Errorf("expected ErrNoSuchTicket, got %s", err)
+	}
+}
+
+func TestServicer_GetTicket_Leased(t *testing.T) {
 	lineageId := createLineage(t)
 
 	request := &api.TicketLeaseRequest{
@@ -288,10 +314,9 @@ func TestServicer_GetTicket_LeasedOk(t *testing.T) {
 	if resp.State != "leased" {
 		t.Error("ticket should be in leased state")
 	}
-
 }
 
-func TestServicer_GetTicket_ClosedOk(t *testing.T) {
+func TestServicer_GetTicket_Closed(t *testing.T) {
 	lineageId := createLineage(t)
 
 	request := &api.TicketLeaseRequest{
@@ -316,7 +341,6 @@ func TestServicer_GetTicket_ClosedOk(t *testing.T) {
 	if resp.State != "closed" {
 		t.Error("ticket should be in leased state")
 	}
-
 }
 
 func createLineage(t *testing.T) string {

--- a/scripts/psql/migrations/1_initialize_schema.down.sql
+++ b/scripts/psql/migrations/1_initialize_schema.down.sql
@@ -1,1 +1,12 @@
--- TODO
+drop table if exists tickets;
+drop table if exists released_tickets;
+drop table if exists lineages;
+
+drop type if exists ticket_lease_status;
+
+drop sequence if exists lockz_rvn;
+drop table if exists lockz;
+
+drop function if exists create_ticket;
+drop function if exists release_ticket;
+drop function if exists close_ticket;


### PR DESCRIPTION
This PR addresses a bug that allowed an inexistent ticket to be patched via closed or released status updates.
Since dinonce is still in beta, I've added a fix to the original db migrations script, so the DB needs to be dropped after this.

Also covered the affected flows with test cases.