### PR TITLE
chore(local): add Makefile targets for psql in Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,14 @@ oapi:
 
 start-postgres:
 	docker run \
-		--rm \
-		--name dinonce-postgres \
-    -p 5433:5432 \
-    -e POSTGRES_USER=postgres \
-    -e POSTGRES_PASSWORD=postgres \
-    -e POSTGRES_DB=postgres \
-    -d postgres
+  --rm \
+  --name dinonce-postgres \
+  --publish 5433:5432 \
+  --env POSTGRES_USER=postgres \
+  --env POSTGRES_PASSWORD=postgres \
+  --env POSTGRES_DB=postgres \
+  --detach \
+  postgres
 
 stop-postgres:
 	docker stop dinonce-postgres

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,19 @@ oapi:
 		mkdir -p $(OAPI_GENERATED_DIR)
 		$(OAPI_CODEGEN) --config=$(DEEPMAP_CONFIG_FILE) $(OAPI_SCHEMA_FILE)
 
+start-postgres:
+	docker run \
+		--rm \
+		--name dinonce-postgres \
+    -p 5433:5432 \
+    -e POSTGRES_USER=postgres \
+    -e POSTGRES_PASSWORD=postgres \
+    -e POSTGRES_DB=postgres \
+    -d postgres
+
+stop-postgres:
+	docker stop dinonce-postgres
+
 clean:
 		rm -rf $(DIST_DIR)
 		rm -rf $(OAPI_GENERATED_DIR)


### PR DESCRIPTION
Add Makefile targets for starting and stopping PostgreSQL container.
- `start-postgres` target: runs a Docker command to start a PostgreSQL container with specific configuration options, such as port mapping and environment variables
- `stop-postgres` target: stops the running PostgreSQL container using Docker.

